### PR TITLE
LocalMedia#removeStream() and LocalMedia#removeTrack() do not properly stop and remove tracks

### DIFF
--- a/lib/media/localmedia.js
+++ b/lib/media/localmedia.js
@@ -109,7 +109,7 @@ LocalMedia.prototype.removeMicrophone = function removeMicrophone(stop) {
   if (microphone) {
     return this.removeTrack(microphone, stop);
   }
-  return null;
+  return microphone;
 };
 
 /**
@@ -155,7 +155,7 @@ LocalMedia.prototype.removeCamera = function removeCamera(stop) {
   if (camera) {
     return this.removeTrack(camera, stop);
   }
-  return null;
+  return camera;
 };
 
 /**

--- a/lib/media/localmedia.js
+++ b/lib/media/localmedia.js
@@ -67,17 +67,6 @@ inherits(LocalMedia, Media);
 LocalMedia.prototype.addTrack = Media.prototype._addTrack;
 
 /**
- * Removes a {@link LocalTrack} from the {@link LocalMedia} object, if it was added.
- * @method
- * @param {LocalTrack} track - The {@link LocalTrack} to remove
- * @param {?boolean} [stop=true] - Whether or not to call
- *   {@link LocalTrack#stop}
- * @returns {this}
- * @fires Media#trackRemoved
- */
-LocalMedia.prototype.removeTrack = Media.prototype._removeTrack;
-
-/**
  * Adds a {@link LocalAudioTrack} representing your browser's microphone to the
  * {@link LocalMedia} object, if not already added.
  * <br><br>
@@ -116,7 +105,7 @@ LocalMedia.prototype.removeMicrophone = function removeMicrophone() {
     microphone = microphone || audioTrack;
   });
   if (microphone) {
-    return this._removeTrack(microphone);
+    return this.removeTrack(microphone);
   }
   return null;
 };
@@ -160,7 +149,7 @@ LocalMedia.prototype.removeCamera = function removeCamera() {
     camera = camera || videoTrack;
   });
   if (camera) {
-    return this._removeTrack(camera);
+    return this.removeTrack(camera);
   }
   return null;
 };
@@ -205,7 +194,16 @@ LocalMedia.prototype.removeStream = function removeStream(mediaStream, stop) {
   return this;
 };
 
-LocalMedia.prototype._removeTrack = function _removeTrack(track, stop) {
+/**
+ * Removes a {@link LocalTrack} from the {@link LocalMedia} object, if it was added.
+ * @method
+ * @param {LocalTrack} track - The {@link LocalTrack} to remove
+ * @param {?boolean} [stop=true] - Whether or not to call
+ *   {@link LocalTrack#stop}
+ * @returns {this}
+ * @fires Media#trackRemoved
+ */
+LocalMedia.prototype.removeTrack = function removeTrack(track, stop) {
   if (typeof stop === 'boolean' ? stop : true) {
     track.stop();
   }

--- a/lib/media/localmedia.js
+++ b/lib/media/localmedia.js
@@ -96,16 +96,18 @@ LocalMedia.prototype.addMicrophone = function addMicrophone() {
 /**
  * Removes the {@link LocalAudioTrack} representing your browser's microphone, if it
  * has been added.
+ * @param {?boolean} [stop=true] - Whether or not to call
+ *   {@link LocalTrack#stop} on the corresponding {@link LocalTrack}
  * @returns {?LocalAudioTrack}
  * @fires Media#trackRemoved
  */
-LocalMedia.prototype.removeMicrophone = function removeMicrophone() {
+LocalMedia.prototype.removeMicrophone = function removeMicrophone(stop) {
   var microphone = null;
   this.audioTracks.forEach(function(audioTrack) {
     microphone = microphone || audioTrack;
   });
   if (microphone) {
-    return this.removeTrack(microphone);
+    return this.removeTrack(microphone, stop);
   }
   return null;
 };
@@ -140,16 +142,18 @@ LocalMedia.prototype.addCamera = function addCamera() {
 /**
  * Removes the {@link LocalVideoTrack} representing your browser's camera, if it
  * has been added.
+ * @param {?boolean} [stop=true] - Whether or not to call
+ *   {@link LocalTrack#stop} on the corresponding {@link LocalTrack}
  * @returns {?LocalVideoTrack}
  * @fires Media#trackRemoved
  */
-LocalMedia.prototype.removeCamera = function removeCamera() {
+LocalMedia.prototype.removeCamera = function removeCamera(stop) {
   var camera = null;
   this.videoTracks.forEach(function(videoTrack) {
     camera = camera || videoTrack;
   });
   if (camera) {
-    return this.removeTrack(camera);
+    return this.removeTrack(camera, stop);
   }
   return null;
 };


### PR DESCRIPTION
Because `LocalMedia#removeTrack()` is [simply calling `Media#_removeTrack()`](https://github.com/twilio/twilio-conversations.js/blob/7259a9b4066a63c2c12890f5b75910cc72fdd565/lib/media/localmedia.js#L69-L78), it doesn't properly stop and remove the track from the media stream, as is being done correctly in `LocalMedia#_removeTrack()`.

My suggestion is to remove the current definition of `LocalMedia#removeTrack()`, and replace it with the current definition of `LocalMedia#_removeTrack()`, [which overrides the underlying `Media#_removeTrack()` properly](https://github.com/twilio/twilio-conversations.js/blob/7259a9b4066a63c2c12890f5b75910cc72fdd565/lib/media/localmedia.js#L208-L220). This will by side-affect fix the behavior of `LocalMedia#removeStream()`, which calls into the current broken definition. There may be some other methods that are correctly calling the current `LocalMedia#removeTrack()` though, and those would need to be changed to call the underlying `Media#_removeTrack()` instead.