### PR TITLE
Update SIPJSDialog and SIPJSMediaHandler for SIP.js 0.7.3

### DIFF
--- a/lib/signaling/sipjsdialog.js
+++ b/lib/signaling/sipjsdialog.js
@@ -128,7 +128,7 @@ SIPJSDialog.prototype._refer = function _refer(target) {
 
   var extraHeaders = [
     'Contact: ' + this.session.contact,
-    'Allow: ' + SIPJS.Utils.getAllowedMethods(this.session.ua),
+    'Allow: ' + SIPJS.UA.C.ALLOWED_METHODS.toString(),
     'Refer-To: ' + this.session.ua.normalizeTarget(target),
     'Allow-Events: refer',
     'Event: refer;id=' + Math.floor((Math.random() * 1000) + 1)

--- a/lib/signaling/sipjsmediahandler.js
+++ b/lib/signaling/sipjsmediahandler.js
@@ -184,6 +184,14 @@ SIPJSMediaHandler.prototype.close = function close() {
   }
 };
 
+SIPJSMediaHandler.prototype.hold = function hold() {
+  // NOTE(mroberts): We don't use SIP.js's hold functionality.
+};
+
+SIPJSMediaHandler.prototype.unhold = function unhold() {
+  // NOTE(mroberts): We don't use SIP.js's hold functionality.
+};
+
 SIPJSMediaHandler.prototype.getDescription = function getDescription(options) {
   var self = this;
 
@@ -221,7 +229,6 @@ SIPJSMediaHandler.prototype.getDescription = function getDescription(options) {
 
     sdp = SIP.Hacks.Chrome.needsExplicitlyInactiveSDP(sdp);
     sdp = SIP.Hacks.AllBrowsers.unmaskDtls(sdp);
-    sdp = SIP.Hacks.Firefox.hasIncompatibleCLineWithSomeSIPEndpoints(sdp);
     sdp = SIP.Hacks.Firefox.hasMissingCLineInSDP(sdp);
 
     self.emit('getDescription', {
@@ -233,9 +240,7 @@ SIPJSMediaHandler.prototype.getDescription = function getDescription(options) {
 
     return {
       body: sdp,
-      extraHeaders: [
-        'Content-Type: application/sdp'
-      ]
+      contentType: 'application/sdp'
     };
   }).catch(function getDescriptionFailed(error) {
     self._ready = true;
@@ -266,8 +271,16 @@ SIPJSMediaHandler.prototype.hasDescription = function hasDescription(message) {
   return hasSDP;
 };
 
+SIPJSMediaHandler.prototype.isMuted = function isMuted() {
+  // NOTE(mroberts): We don't use SIP.js's mute behavior.
+  return {
+    audio: false,
+    video: false
+  };
+};
+
 SIPJSMediaHandler.prototype.mute = function mute() {
-  // Do nothing.
+  // NOTE(mroberts): We don't use SIP.js's mute behavior.
 };
 
 SIPJSMediaHandler.prototype.render = function render() {
@@ -303,7 +316,12 @@ SIPJSMediaHandler.prototype.setDescription = function setDescription(message) {
 };
 
 SIPJSMediaHandler.prototype.unmute = function unmute() {
-  // Do nothing.
+  // NOTE(mroberts): We don't use SIP.js's mute behavior.
+};
+
+SIPJSMediaHandler.prototype.updateIceServers = function updateIceServers(servers) {
+  // NOTE(mroberts): We don't support ICE restart yet.
+  void servers;
 };
 
 function getConversationInfo(message) {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "dependencies": {
-    "sip.js": "https://github.com/twilio/SIP.js.git#4e74f060191cdc8657737fdc7947af5eff871a4b",
+    "sip.js": "https://github.com/twilio/SIP.js.git#a08566df1f4e3a109c44b3584532d495e8bf5310",
     "twilio-common": "^0.1.4",
     "ws": "^0.6.3",
     "xmlhttprequest": "^1.8.0"


### PR DESCRIPTION
@ryan-rowland mind taking a look? This PR updates twilio-conversations.js to use Twilio's fork of SIP.js 0.7.3. There are some new required methods on MediaHandler instances, and the
`getAllowedMethods` function has gone away from the top-level SIP.js object.