### PR TITLE
Callstats api integration

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -66,6 +66,10 @@ function Client(accessManager, options) {
   var UserAgent = options.userAgent;
   var userAgent = new UserAgent(accessManager, options);
 
+  /* global callStats appId appSecret csInitCallback */
+  /* eslint no-undef: 2 */
+  callStats.initialize(appId, appSecret, accessManager.identity, csInitCallback, null, null);
+
   userAgent.on('invite', function onInviteServerTransaction(inviteServerTransaction) {
     var cookie = inviteServerTransaction.cookie;
     var outgoingInvite = outgoingInvites.get(cookie) || canceledOutgoingInvites.get(cookie);

--- a/lib/client.js
+++ b/lib/client.js
@@ -68,7 +68,7 @@ function Client(accessManager, options) {
 
   /* global callStats appId appSecret csInitCallback */
   /* eslint no-undef: 2 */
-  callStats.initialize(appId, appSecret, accessManager.identity, csInitCallback, null, null);
+  callStats.initialize(appId, appSecret, accessManager.identity, csInitCallback);
 
   userAgent.on('invite', function onInviteServerTransaction(inviteServerTransaction) {
     var cookie = inviteServerTransaction.cookie;

--- a/lib/signaling/sipjsmediahandler.js
+++ b/lib/signaling/sipjsmediahandler.js
@@ -242,6 +242,7 @@ SIPJSMediaHandler.prototype.getDescription = function getDescription(options) {
     }
   }).then(function createOfferOrAnswerSucceeded(description) {
     return new Promise(function(resolve, reject) {
+      csioWebRTCFunction = callStats.webRTCFunctions.setLocalDescription;
       self.peerConnection.setLocalDescription(description, resolve, reject);
     });
   }).then(function setLocalDescriptionSucceeded() {
@@ -345,6 +346,8 @@ SIPJSMediaHandler.prototype.setDescription = function setDescription(message) {
     self._signalingState = self._signalingState === 'stable'
       ? 'have-remote-offer'
       : 'stable';
+  }).catch(function setRemoteDescriptionFailed(error) {
+    callStats.reportError(self.peerConnection, self.confId, callStats.webRTCFunctions.setRemoteDescription, error);
   });
 };
 

--- a/lib/signaling/sipjsmediahandler.js
+++ b/lib/signaling/sipjsmediahandler.js
@@ -20,6 +20,8 @@ function SIPJSMediaHandler(session, options) {
   var localMedia = null;
   var peerConnection;
   var ready = true;
+  var confId = null;
+  var fromId = null;
 
   // NOTE(mroberts): SIP.js currently relies on PeerConnection signalingState
   // to detect whether it has a local or remote offer. A more robust solution
@@ -67,6 +69,22 @@ function SIPJSMediaHandler(session, options) {
         localMedia = _localMedia;
       }
     },
+    confId: {
+      get: function() {
+        return confId;
+      },
+      set: function(_confId) {
+        confId = _confId;
+      }
+    },
+    fromId: {
+      get: function() {
+        return fromId;
+      },
+      set: function(_fromId) {
+        fromId = _fromId;
+      }
+    },
     peerConnection: {
       enumerable: true,
       get: function() {
@@ -94,6 +112,14 @@ SIPJSMediaHandler.prototype._createPeerConnection = function _createPeerConnecti
   var stunServers = options.stunServers || config.stunServers || [];
   var turnServers = options.turnServers || config.turnServers || [];
   var servers = [];
+
+  var request = session.request;
+
+  if (request) {
+    this.confId = util.parseConversationSIDFromContactHeader(request.getHeader('Contact'));
+    this.fromId = request.from.uri.user;
+  }
+
 
   // A note from SIP.js:
   //
@@ -203,6 +229,8 @@ SIPJSMediaHandler.prototype.getDescription = function getDescription(options) {
   this._ready = false;
 
   return new Promise(function createOfferOrAnswer(resolve, reject) {
+    callStats.addNewFabric(self.peerConnection, self.fromId, callStats.fabricUsage.multiplex, self.confId, null);
+    /* global callStats */
     if (self._signalingState === 'stable') {
       self.peerConnection.createOffer(resolve, reject, C.DEFAULT_OFFER_OPTIONS);
     } else {

--- a/lib/signaling/sipjsmediahandler.js
+++ b/lib/signaling/sipjsmediahandler.js
@@ -206,6 +206,7 @@ SIPJSMediaHandler.prototype._createPeerConnection = function _createPeerConnecti
 
 SIPJSMediaHandler.prototype.close = function close() {
   if (this.peerConnection.state !== 'closed') {
+    callStats.sendFabricEvent(this.peerConnection, callStats.fabricEvent.fabricTerminated, this.confId);
     this.peerConnection.close();
   }
 };
@@ -227,13 +228,16 @@ SIPJSMediaHandler.prototype.getDescription = function getDescription(options) {
   }
 
   this._ready = false;
+  var csioWebRTCFunction;
 
   return new Promise(function createOfferOrAnswer(resolve, reject) {
-    callStats.addNewFabric(self.peerConnection, self.fromId, callStats.fabricUsage.multiplex, self.confId, null);
+    callStats.addNewFabric(self.peerConnection, self.fromId, callStats.fabricUsage.multiplex, self.confId);
     /* global callStats */
     if (self._signalingState === 'stable') {
+      csioWebRTCFunction = callStats.webRTCFunctions.createOffer;
       self.peerConnection.createOffer(resolve, reject, C.DEFAULT_OFFER_OPTIONS);
     } else {
+      csioWebRTCFunction = callStats.webRTCFunctions.createAnswer;
       self.peerConnection.createAnswer(resolve, reject);
     }
   }).then(function createOfferOrAnswerSucceeded(description) {
@@ -272,6 +276,7 @@ SIPJSMediaHandler.prototype.getDescription = function getDescription(options) {
     };
   }).catch(function getDescriptionFailed(error) {
     self._ready = true;
+    callStats.reportError(self.peerConnection, self.confId, csioWebRTCFunction, error);
     throw new SIP.Exceptions.GetDescriptionError(error);
   });
 };

--- a/src/twilio-conversations.js
+++ b/src/twilio-conversations.js
@@ -4,6 +4,19 @@
  */
 /* eslint strict:0 */
 (function(root) {
+  /* eslint "no-unused-vars": [2, {"vars": "all", "varsIgnorePattern": "a"}] */
+  var appId = '175240362';
+  var appSecret = 'Gvd126EUWQheaWQX9mwmeWIbzvs=';
+
+  /* global callstats io jsSHA */
+  /* eslint no-undef: 2 */
+  /* eslint new-cap: [2, {"newIsCap": false}] */
+  var callStats = new callstats(null, io, jsSHA);
+
+  function csInitCallback(err, msg) {
+    console.log('CallStats Initializing Status: err=' + err + 'msg=' + msg);
+  }
+
   var Conversations = require('./twilio-conversations-bundle');
   /* globals define */
   if (typeof define === 'function' && define.amd) {

--- a/src/twilio-conversations.js
+++ b/src/twilio-conversations.js
@@ -5,8 +5,8 @@
 /* eslint strict:0 */
 (function(root) {
   /* eslint "no-unused-vars": [2, {"vars": "all", "varsIgnorePattern": "a"}] */
-  var appId = '175240362';
-  var appSecret = 'Gvd126EUWQheaWQX9mwmeWIbzvs=';
+  var appId = '';
+  var appSecret = '';
 
   /* global callstats io jsSHA */
   /* eslint no-undef: 2 */


### PR DESCRIPTION
callstats.io monitors and manages the performance of video calls in an WebRTC application. 
This PR integrates the callstats APIs in twilio-conversations.js

Pending -

reportError has to be integrated for catching the getUserMediaError - in the file lib/media/localmedia.js
(For integration conferenceID is necessary)
The fabric events such as mute/unmute pause/play has to be integrated as well.


