### PR TITLE
rename function to prevent a `strict mode` error

### DIFF
--- a/lib/signaling/v2/conversation.js
+++ b/lib/signaling/v2/conversation.js
@@ -308,7 +308,7 @@ function handleSessionEvents(conversationV2, session) {
   session.on('info', infoOrNotify);
   session.on('notify', infoOrNotify);
 
-  session.mediaHandler.on('conversationInfo', function conversationInfo(conversationInfo) {
+  session.mediaHandler.on('conversationInfo', function conversationInfoFn(conversationInfo) {
     conversationV2._onNotification(conversationInfo, false);
   });
 


### PR DESCRIPTION
The `conversationInfo` function is shadowed by the `conversationInfo` parameter which results in a SyntaxError.